### PR TITLE
fix Windows x64 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **TrollCoin (TROLL) Version 2.1.0.0**
+# **TrollCoin (TROLL) Version 2.1.1.0**
 
 TrollCoin Integration/Staging Tree
 ================================

--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -1,4 +1,4 @@
-trollcoin (2.1.0.0) unstable; urgency=low
+trollcoin (2.1.1.0) unstable; urgency=low
 
   * Update debian package scripts for use by trollcoin.
 

--- a/doc/qt-windows10-static-build.ps1.patch
+++ b/doc/qt-windows10-static-build.ps1.patch
@@ -1,0 +1,23 @@
+--- qt-windows10-static-build.ps1	2022-06-05 16:07:19.249368051 +0200
++++ qt-windows10-static-build.ps1.bak	2022-06-05 16:10:54.731007279 +0200
+@@ -134,7 +134,10 @@
+     }
+ 
+     # Set a clean path including MinGW.
+-    $env:Path += "$MingwDir\bin;$MingwDir\opt\bin;$env:SystemRoot\system32;$env:SystemRoot;$env:SystemRoot\system32\WindowsPowerShell\v1.0\;"
++    $perlPath = Split-Path -parent (get-command perl).Path
++    $pythonPath = Split-Path -parent (get-command python).Path
++    $rubyPath = Split-Path -parent (get-command ruby).Path
++    $env:Path = "$MingwDir\bin;$MingwDir\opt\bin;$env:SystemRoot\system32;$env:SystemRoot;$env:SystemRoot\system32\WindowsPowerShell\v1.0\;$perlPath;$pythonPath;$rubyPath"
+ 	
+ 	
+     # Check that the 'powershell' command is available
+@@ -155,7 +158,7 @@
+ 
+     # Configure, compile and install Qt.
+     Push-Location $QtSrcDir
+-    cmd /c "configure.bat -static -release -platform win32-g++ -opensource -confirm-license -prefix $QtDir -qt-zlib -qt-libpng -qt-webp -qt-libjpeg -qt-freetype  -no-opengl -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtconnectivity -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtlocation -skip qtlottie -skip qtmacextras -skip qtmultimedia -skip qtnetworkauth -skip qtpurchasing -skip qtquick3d -skip qtquickcontrols -skip qtquickcontrols2 -skip qtquicktimeline -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtspeech -skip qtsvg -skip qtwayland -skip qtwebglplugin -skip qtwebview -skip webengine -make libs -nomake tools -nomake examples -nomake tests"
++    cmd /c "configure.bat -static -release -platform win32-g++ -opensource -confirm-license -prefix $QtDir -qt-zlib -qt-libpng -qt-libjpeg -qt-freetype -no-opengl -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtconnectivity -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtlocation -skip qtmacextras -skip qtmultimedia -skip qtnetworkauth -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtspeech -skip qtsvg -skip qtwayland -skip qtwebview -skip webengine -make libs -nomake tools -nomake examples -nomake tests"
+     mingw32-make #-k -j4
+     mingw32-make install #-k install
+     Pop-Location

--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -1,5 +1,5 @@
 TrollCoin-qt: Qt5 GUI for TrollCoin
-===============================
+===================================
 
 Build instructions
 ===================
@@ -32,15 +32,97 @@ An executable named `trollcoin-qt` will be built.
 Windows
 --------
 
-Windows build instructions:
+Windows build instructions to build a 64-bit binary. These are compiled natively on Windows,
+not cross-compiled from Linux:
 
-- Download the `QT Windows SDK`_ and install it. You don't need the Symbian stuff, just the desktop Qt.
+- Download and install `msys2`_ and `7zip`_.
+- Open a mingw64 shell (C:/msys64/mingw64.exe) and cd into the trollcoin source directory
+- Run
 
-- Compile openssl, boost and dbcxx.
+::
 
-- Open the .pro file in QT creator and build as normal (ctrl-B)
+    pacman -Syy --noconfirm mingw-w64-x86_64-gcc make patch ruby python
+    wget https://github.com/miurahr/aqtinstall/releases/download/v2.1.0/aqt.exe
+    ./aqt install-tool --outputdir c:/Qt windows desktop tools_mingw qt.tools.win64_mingw810
 
-.. _`QT Windows SDK`: http://qt-project.org/downloads
+
+Build Qt statically
+^^^^^^^^^^^^^^^^^^^^^^
+
+This allows to distribute a single .exe in the end, otherwise many Qt dlls need to be distributed alongside the .exe.
+If this is not required, you can simply install the regular `Qt installer`_ and build with that.
+
+::
+
+    wget https://gist.githubusercontent.com/mrfaptastic/80e909c9a8237994471bce2d17657779/raw/62596d3986b6e655f260efb51a2a9e630cd24a20/qt-windows10-static-build.ps1
+    patch < doc/qt-windows10-static-build.ps1.patch
+    powershell -File qt-windows10-static-build.ps1 -NoPause -QtVersion 5.9.9 -QtSrcUrl https://download.qt.io/archive/qt/5.9/5.9.9/single/qt-everywhere-opensource-src-5.9.9.zip
+
+
+Build dependencies
+^^^^^^^^^^^^^^^^^^
+
+Download the dependencies from the linked URLs, extract the archives and then run the
+commands below in the respective extracted folder.
+
+Build boost (version 1.55.0 https://sourceforge.net/projects/boost/files/boost/1.55.0):
+
+::
+
+    ./bootstrap.sh --with-toolset=mingw --prefix=C:/boost --with-libraries=system,filesystem,program_options,thread,chrono
+    sed -i "s/mingw/gcc/g" project-config.jam
+    ./b2 install
+
+Build libdb (version 5.3.28 https://github.com/berkeleydb/libdb/releases/tag/v5.3.28):
+
+::
+
+    cd build_unix
+    ../dist/configure --prefix=/c/libdb --enable-mingw --enable-cxx
+    make -j
+    make install
+
+Build openssl (version 1.0.2u https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz):
+
+::
+
+    mkdir -p /c/openssl
+    ./Configure --prefix=/c/openssl --openssldir=/c/openssl no-shared --release mingw64
+    make
+    make install
+
+Build miniupnpc (version 2.2.3 http://miniupnp.free.fr/files/download.php?file=miniupnpc-2.2.3.tar.gz):
+
+::
+
+
+    make -f Makefile.mingw
+    mkdir -p /c/miniupnpc/{include/miniupnpc,lib}
+    cp include/* /c/miniupnpc/include/miniupnpc
+    cp *.a /c/miniupnpc/lib
+
+Build qrencode (version 4.1.1 https://fukuchi.org/works/qrencode/qrencode-4.1.1.tar.gz):
+
+::
+
+    ./configure --prefix=/c/qrencode --disable-shared
+    make -j
+    make install
+
+
+Build trollcoin
+^^^^^^^^^^^^^^^
+
+::
+
+    export PATH=/c/Qt/Static/5.9.9/bin:$PATH
+    qmake "USE_UPNP=1" "USE_QRCODE=1" "BOOST_LIB_PATH=C:\boost\lib" "BOOST_LIB_SUFFIX=-mgw121-mt-1_55" "BOOST_INCLUDE_PATH=C:\boost\include\boost-1_55" "OPENSSL_LIB_PATH=C:\openssl\lib" "OPENSSL_INCLUDE_PATH=C:\openssl\include" "BDB_LIB_PATH=C:\libdb\lib" "BDB_INCLUDE_PATH=C:\libdb\include" "MINIUPNPC_LIB_PATH=C:\miniupnpc\lib" "MINIUPNPC_INCLUDE_PATH=C:\miniupnpc\include" "QRENCODE_LIB_PATH=C:\qrencode\lib" "QRENCODE_INCLUDE_PATH=C:\qrencode\include"
+    make
+
+
+.. _`msys2`: https://www.msys2.org/
+.. _`7zip`: https://www.7-zip.org/
+.. _`Qt installer`: https://www.qt.io/download-thank-you?os=windows&hsLang=en
 
 
 Mac OS X

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -8,7 +8,7 @@
 // These need to be macros, as version.cpp's and bitcoin-qt.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR       2
 #define CLIENT_VERSION_MINOR       1
-#define CLIENT_VERSION_REVISION    0
+#define CLIENT_VERSION_REVISION    1
 #define CLIENT_VERSION_BUILD       0
 
 // Set to true for release, false for prerelease or test build

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -63,7 +63,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string notr="true">2.1.0.0</string>
+          <string notr="true">2.1.1.0</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/trollcoin-qt.pro
+++ b/trollcoin-qt.pro
@@ -42,6 +42,10 @@ OBJECTS_DIR = build
 MOC_DIR = build
 UI_DIR = build
 
+# Force c++11 standard to workaround boost 1.55 compilation errors with
+# newer compilers.
+QMAKE_CXXFLAGS += -std=c++11
+
 # use: qmake "RELEASE=1"
 contains(RELEASE, 1) {
     macx:QMAKE_CXXFLAGS += -mmacosx-version-min=10.7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk

--- a/trollcoin-qt.pro
+++ b/trollcoin-qt.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 TARGET = TrollCoin
-VERSION = 2.1.0.0
+VERSION = 2.1.1.0
 
 greaterThan(QT_MAJOR_VERSION, 5) {
     INCLUDEPATH += src src/json src/qt src/qt/plugins/mrichtexteditor


### PR DESCRIPTION
I updated the build instructions to build working x64 builds for Windows that allow to sync to the current chain tip instead of crashing after blocks at something like December 2021 because of out-of-memory errors.

I also bumped the version number to `2.1.1`. I attached a binary for you to test, or you build it yourself with the instructions from the readme.

[TrollCoin.zip](https://github.com/TrollCoin2/TrollCoin-2.0/files/9276892/TrollCoin.zip)
